### PR TITLE
Create a sample app to show off the Library Browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ DerivedData
 *.ipa
 *.xcuserstate
 .DS_Store
+AdobeCreativeSDKFrameworks/*

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser.xcodeproj/project.pbxproj
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser.xcodeproj/project.pbxproj
@@ -1,0 +1,384 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		41D75A181CED30E900F57F9B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 41D75A171CED30E900F57F9B /* main.m */; };
+		41D75A1B1CED30E900F57F9B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 41D75A1A1CED30E900F57F9B /* AppDelegate.m */; };
+		41D75A1E1CED30E900F57F9B /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 41D75A1D1CED30E900F57F9B /* ViewController.m */; };
+		41D75A211CED30E900F57F9B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A1F1CED30E900F57F9B /* Main.storyboard */; };
+		41D75A231CED30E900F57F9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A221CED30E900F57F9B /* Assets.xcassets */; };
+		41D75A261CED30E900F57F9B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A241CED30E900F57F9B /* LaunchScreen.storyboard */; };
+		41D75A2E1CED338B00F57F9B /* AdobeCreativeSDKCoreResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A2D1CED338B00F57F9B /* AdobeCreativeSDKCoreResources.bundle */; };
+		41D75A301CED33A000F57F9B /* AdobeCreativeSDKCommonUXResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A2F1CED339F00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */; };
+		41D75A321CED33BA00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A311CED33BA00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */; };
+		41D75A371CED33C900F57F9B /* AdobeCreativeSDKAssetModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A331CED33C900F57F9B /* AdobeCreativeSDKAssetModel.framework */; };
+		41D75A381CED33C900F57F9B /* AdobeCreativeSDKAssetUX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A341CED33C900F57F9B /* AdobeCreativeSDKAssetUX.framework */; };
+		41D75A391CED33C900F57F9B /* AdobeCreativeSDKCommonUX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A351CED33C900F57F9B /* AdobeCreativeSDKCommonUX.framework */; };
+		41D75A3A1CED33C900F57F9B /* AdobeCreativeSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A361CED33C900F57F9B /* AdobeCreativeSDKCore.framework */; };
+		41D75A3C1CED33DF00F57F9B /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A3B1CED33DF00F57F9B /* libz.tbd */; };
+		41D75A3E1CED33EC00F57F9B /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A3D1CED33EC00F57F9B /* libc++.tbd */; };
+		41D75A411CED340A00F57F9B /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A3F1CED340A00F57F9B /* MobileCoreServices.framework */; };
+		41D75A421CED340A00F57F9B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A401CED340A00F57F9B /* SystemConfiguration.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		41D75A131CED30E900F57F9B /* library-browser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "library-browser.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		41D75A171CED30E900F57F9B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		41D75A191CED30E900F57F9B /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		41D75A1A1CED30E900F57F9B /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		41D75A1C1CED30E900F57F9B /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		41D75A1D1CED30E900F57F9B /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		41D75A201CED30E900F57F9B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		41D75A221CED30E900F57F9B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		41D75A251CED30E900F57F9B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		41D75A271CED30E900F57F9B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		41D75A2D1CED338B00F57F9B /* AdobeCreativeSDKCoreResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKCoreResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCore.framework/Versions/A/Resources/AdobeCreativeSDKCoreResources.bundle; sourceTree = "<group>"; };
+		41D75A2F1CED339F00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKCommonUXResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCommonUX.framework/Versions/A/Resources/AdobeCreativeSDKCommonUXResources.bundle; sourceTree = "<group>"; };
+		41D75A311CED33BA00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKAssetUXResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetUX.framework/Versions/A/Resources/AdobeCreativeSDKAssetUXResources.bundle; sourceTree = "<group>"; };
+		41D75A331CED33C900F57F9B /* AdobeCreativeSDKAssetModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKAssetModel.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetModel.framework; sourceTree = "<group>"; };
+		41D75A341CED33C900F57F9B /* AdobeCreativeSDKAssetUX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKAssetUX.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetUX.framework; sourceTree = "<group>"; };
+		41D75A351CED33C900F57F9B /* AdobeCreativeSDKCommonUX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKCommonUX.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCommonUX.framework; sourceTree = "<group>"; };
+		41D75A361CED33C900F57F9B /* AdobeCreativeSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKCore.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCore.framework; sourceTree = "<group>"; };
+		41D75A3B1CED33DF00F57F9B /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		41D75A3D1CED33EC00F57F9B /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		41D75A3F1CED340A00F57F9B /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		41D75A401CED340A00F57F9B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		41D75A101CED30E900F57F9B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75A371CED33C900F57F9B /* AdobeCreativeSDKAssetModel.framework in Frameworks */,
+				41D75A381CED33C900F57F9B /* AdobeCreativeSDKAssetUX.framework in Frameworks */,
+				41D75A391CED33C900F57F9B /* AdobeCreativeSDKCommonUX.framework in Frameworks */,
+				41D75A3A1CED33C900F57F9B /* AdobeCreativeSDKCore.framework in Frameworks */,
+				41D75A3E1CED33EC00F57F9B /* libc++.tbd in Frameworks */,
+				41D75A3C1CED33DF00F57F9B /* libz.tbd in Frameworks */,
+				41D75A411CED340A00F57F9B /* MobileCoreServices.framework in Frameworks */,
+				41D75A421CED340A00F57F9B /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		41D75A0A1CED30E900F57F9B = {
+			isa = PBXGroup;
+			children = (
+				41D75A151CED30E900F57F9B /* library-browser */,
+				41D75A141CED30E900F57F9B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		41D75A141CED30E900F57F9B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A131CED30E900F57F9B /* library-browser.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		41D75A151CED30E900F57F9B /* library-browser */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A191CED30E900F57F9B /* AppDelegate.h */,
+				41D75A1A1CED30E900F57F9B /* AppDelegate.m */,
+				41D75A1C1CED30E900F57F9B /* ViewController.h */,
+				41D75A1D1CED30E900F57F9B /* ViewController.m */,
+				41D75A1F1CED30E900F57F9B /* Main.storyboard */,
+				41D75A221CED30E900F57F9B /* Assets.xcassets */,
+				41D75A241CED30E900F57F9B /* LaunchScreen.storyboard */,
+				41D75A271CED30E900F57F9B /* Info.plist */,
+				41D75A161CED30E900F57F9B /* Supporting Files */,
+			);
+			path = "library-browser";
+			sourceTree = "<group>";
+		};
+		41D75A161CED30E900F57F9B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A731CEE750700F57F9B /* CSDK Frameworks */,
+				41D75A721CEE74FD00F57F9B /* CSDK Resources */,
+				41D75A741CEE751200F57F9B /* System Frameworks */,
+				41D75A171CED30E900F57F9B /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		41D75A721CEE74FD00F57F9B /* CSDK Resources */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A311CED33BA00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */,
+				41D75A2F1CED339F00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */,
+				41D75A2D1CED338B00F57F9B /* AdobeCreativeSDKCoreResources.bundle */,
+			);
+			name = "CSDK Resources";
+			sourceTree = "<group>";
+		};
+		41D75A731CEE750700F57F9B /* CSDK Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A331CED33C900F57F9B /* AdobeCreativeSDKAssetModel.framework */,
+				41D75A341CED33C900F57F9B /* AdobeCreativeSDKAssetUX.framework */,
+				41D75A351CED33C900F57F9B /* AdobeCreativeSDKCommonUX.framework */,
+				41D75A361CED33C900F57F9B /* AdobeCreativeSDKCore.framework */,
+			);
+			name = "CSDK Frameworks";
+			sourceTree = "<group>";
+		};
+		41D75A741CEE751200F57F9B /* System Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A3F1CED340A00F57F9B /* MobileCoreServices.framework */,
+				41D75A401CED340A00F57F9B /* SystemConfiguration.framework */,
+				41D75A3D1CED33EC00F57F9B /* libc++.tbd */,
+				41D75A3B1CED33DF00F57F9B /* libz.tbd */,
+			);
+			name = "System Frameworks";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		41D75A121CED30E900F57F9B /* library-browser */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41D75A2A1CED30E900F57F9B /* Build configuration list for PBXNativeTarget "library-browser" */;
+			buildPhases = (
+				41D75A0F1CED30E900F57F9B /* Sources */,
+				41D75A101CED30E900F57F9B /* Frameworks */,
+				41D75A111CED30E900F57F9B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "library-browser";
+			productName = "library-browser";
+			productReference = 41D75A131CED30E900F57F9B /* library-browser.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		41D75A0B1CED30E900F57F9B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = Adobe;
+				TargetAttributes = {
+					41D75A121CED30E900F57F9B = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 41D75A0E1CED30E900F57F9B /* Build configuration list for PBXProject "library-browser" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 41D75A0A1CED30E900F57F9B;
+			productRefGroup = 41D75A141CED30E900F57F9B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				41D75A121CED30E900F57F9B /* library-browser */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		41D75A111CED30E900F57F9B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75A321CED33BA00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle in Resources */,
+				41D75A301CED33A000F57F9B /* AdobeCreativeSDKCommonUXResources.bundle in Resources */,
+				41D75A2E1CED338B00F57F9B /* AdobeCreativeSDKCoreResources.bundle in Resources */,
+				41D75A261CED30E900F57F9B /* LaunchScreen.storyboard in Resources */,
+				41D75A231CED30E900F57F9B /* Assets.xcassets in Resources */,
+				41D75A211CED30E900F57F9B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		41D75A0F1CED30E900F57F9B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75A1E1CED30E900F57F9B /* ViewController.m in Sources */,
+				41D75A1B1CED30E900F57F9B /* AppDelegate.m in Sources */,
+				41D75A181CED30E900F57F9B /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		41D75A1F1CED30E900F57F9B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				41D75A201CED30E900F57F9B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		41D75A241CED30E900F57F9B /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				41D75A251CED30E900F57F9B /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		41D75A281CED30E900F57F9B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		41D75A291CED30E900F57F9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		41D75A2B1CED30E900F57F9B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../AdobeCreativeSDKFrameworks";
+				INFOPLIST_FILE = "library-browser/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.adobe.csdk.samples.library-browser";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		41D75A2C1CED30E900F57F9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../AdobeCreativeSDKFrameworks";
+				INFOPLIST_FILE = "library-browser/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.adobe.csdk.samples.library-browser";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		41D75A0E1CED30E900F57F9B /* Build configuration list for PBXProject "library-browser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41D75A281CED30E900F57F9B /* Debug */,
+				41D75A291CED30E900F57F9B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		41D75A2A1CED30E900F57F9B /* Build configuration list for PBXNativeTarget "library-browser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41D75A2B1CED30E900F57F9B /* Debug */,
+				41D75A2C1CED30E900F57F9B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 41D75A0B1CED30E900F57F9B /* Project object */;
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:library-browser.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/AppDelegate.h
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/AppDelegate.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/AppDelegate.m
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/AppDelegate.m
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    // Sent when the application is about to move from active to inactive state. This can occur for
+    // certain types of temporary interruptions (such as an incoming phone call or SMS message) or
+    // when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame
+    // rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    // Use this method to release shared resources, save user data, invalidate timers, and store
+    // enough application state information to restore your application to its current state in
+    // case it is terminated later.
+    // If your application supports background execution, this method is called instead of
+    // applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    // Called as part of the transition from the background to the inactive state; here you can
+    // undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    // Restart any tasks that were paused (or not yet started) while the application was inactive.
+    // If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    // Called when the application is about to terminate. Save data if appropriate. See also
+    // applicationDidEnterBackground:.
+}
+
+@end

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,73 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Base.lproj/LaunchScreen.storyboard
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Base.lproj/Main.storyboard
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Base.lproj/Main.storyboard
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AQr-DW-Kij">
+                                <rect key="frame" x="225" y="28" width="150" height="30"/>
+                                <state key="normal" title="Show Library Browser"/>
+                                <connections>
+                                    <action selector="showLibraryBrowserTouchUpInside" destination="BYZ-38-t0r" eventType="touchUpInside" id="qxk-xm-lFk"/>
+                                </connections>
+                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jeE-V5-O7a">
+                                <rect key="frame" x="20" y="66" width="560" height="514"/>
+                            </imageView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="pvh-zj-4A7">
+                                <rect key="frame" x="282" y="282" width="37" height="37"/>
+                                <color key="color" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            </activityIndicatorView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="AQr-DW-Kij" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="28" id="2fF-En-jzs"/>
+                            <constraint firstAttribute="bottom" secondItem="jeE-V5-O7a" secondAttribute="bottom" constant="20" id="3wK-Gb-CSY"/>
+                            <constraint firstItem="pvh-zj-4A7" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="6Yn-Wb-vDa"/>
+                            <constraint firstItem="jeE-V5-O7a" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" id="I25-c8-fao"/>
+                            <constraint firstItem="AQr-DW-Kij" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="RF1-lw-qCE"/>
+                            <constraint firstAttribute="trailing" secondItem="jeE-V5-O7a" secondAttribute="trailing" constant="20" id="adF-6T-MtX"/>
+                            <constraint firstItem="pvh-zj-4A7" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="wno-Jl-DeI"/>
+                            <constraint firstItem="jeE-V5-O7a" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="66" id="yIY-55-SRV"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="activityIndicator" destination="pvh-zj-4A7" id="bTK-RO-lL1"/>
+                        <outlet property="selectionThumbnailImageView" destination="jeE-V5-O7a" id="Yor-2U-WS1"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="66" y="671"/>
+        </scene>
+    </scenes>
+</document>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Info.plist
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.h
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.m
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.m
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#import <AdobeCreativeSDKCore/AdobeCreativeSDKCore.h>
+#import <AdobeCreativeSDKAssetModel/AdobeCreativeSDKAssetModel.h>
+#import <AdobeCreativeSDKAssetUX/AdobeCreativeSDKAssetUX.h>
+
+#import "ViewController.h"
+
+#warning Please update the ClientId and Secret to the values provided by creativesdk.com or from Adobe
+static NSString * const kCreativeSDKClientId = @"Change Me";
+static NSString * const kCreativeSDKClientSecret = @"Change Me";
+
+@interface ViewController () <AdobeUXAssetBrowserViewControllerDelegate>
+
+@property (weak, nonatomic) IBOutlet UIImageView *selectionThumbnailImageView;
+@property (weak, nonatomic) IBOutlet UIActivityIndicatorView *activityIndicator;
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+    
+    // Set the client ID and secret values so the SDK can identify the calling app.
+    [[AdobeUXAuthManager sharedManager] setAuthenticationParametersWithClientID:kCreativeSDKClientId
+                                                               withClientSecret:kCreativeSDKClientSecret];
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - UI Actions
+
+- (IBAction)showLibraryBrowserTouchUpInside
+{
+    // Only show the Library datasource in the Asset Browser. This helps keep this test app focused.
+    AdobeAssetDataSourceFilter *datasourceFilter =
+        [[AdobeAssetDataSourceFilter alloc] initWithDataSources:@[AdobeAssetDataSourceLibrary]
+                                                     filterType:AdobeAssetDataSourceFilterInclusive];
+    
+    // Create an Asset Browser configuration object that can be used to filter the datasources and
+    // to specify the supported Library item types.
+    AdobeUXAssetBrowserConfiguration *configuration = [AdobeUXAssetBrowserConfiguration new];
+    configuration.dataSourceFilter = datasourceFilter;
+    
+    // Create a new instance of the Asset Brwoser view contrller, set it's configuration and
+    // delegate and present it.
+    AdobeUXAssetBrowserViewController *assetBrowser =
+        [AdobeUXAssetBrowserViewController assetBrowserViewControllerWithConfiguration:configuration
+                                                                              delegate:self];
+    
+    [self presentViewController:assetBrowser animated:YES completion:nil];
+}
+
+#pragma mark - AdobeUXAssetBrowserViewControllerDelegate
+
+- (void)assetBrowserDidSelectAssets:(AdobeSelectionAssetArray *)itemSelections
+{
+    // Dismiss the Asset Browser view controller.
+    [self dismissViewControllerAnimated:YES completion:nil];
+    
+    // Grab the first selected item. This item is the a selection object that has information about
+    // the selected item(s). We can use this object to pinpoint the selected Library item and
+    // perform interesting tasks, like downloading a thumbnail.
+    AdobeSelectionLibraryAsset *librarySelection = itemSelections.firstObject;
+    
+    // Make sure we're dealing with a Library selection object.
+    if (IsAdobeSelectionLibraryAsset(librarySelection))
+    {
+        // Grab the Library object.
+        AdobeAssetLibrary *library = (AdobeAssetLibrary *)librarySelection.selectedItem;
+        
+        // Get the first selected item ID.
+        NSString *selectedImageId = librarySelection.selectedImageIDs.firstObject;
+        
+        // Now get the selected item, in this case an image, from the Library. Note that, for this
+        // demo, we only handline images, however all other supported Library item types can be
+        // retrieved and processed.
+        AdobeAssetLibraryItemImage *libraryImage = library.images[selectedImageId];
+        
+        // Get the rendition file reference. This reference can be used to download the rendition
+        // from the server.
+        AdobeAssetFile *thumbnailFile = libraryImage.rendition;
+        
+        // If the Library item doesn't have a rendition, fall back to the actual image data.
+        if (thumbnailFile == nil)
+        {
+            thumbnailFile = libraryImage.image;
+        }
+        
+        // We can't find any usable data to download, we bail out.
+        if (thumbnailFile == nil)
+        {
+            NSString *message = @"For the purposes of this demo, please select an image/graphic Library item type.";
+            
+            NSLog(@"%@", message);
+            
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Demo"
+                                                                                     message:message
+                                                                              preferredStyle:UIAlertControllerStyleAlert];
+            
+            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
+                                                               style:UIAlertActionStyleDefault
+                                                             handler:nil];
+            
+            [alertController addAction:okAction];
+            
+            [self presentViewController:alertController animated:YES completion:nil];
+            
+            return;
+        }
+        
+        // Start the activity indicator to get the user feedback.
+        [self.activityIndicator startAnimating];
+        
+        // Kick off the download action. Here we're requesting a PNG rendition with dimensions of
+        // 1024×1024 points. The network request priority is set to normal. We've opted to not
+        // specify a progress handler, however, we've chosen to listen for when the thumbnail is
+        // downloaded successfully, so we can display it, when the request has been canceled and
+        // for when there is an error with the request.
+        [thumbnailFile downloadRenditionWithType:AdobeAssetFileRenditionTypePNG
+                                      dimensions:CGSizeMake(1024, 1024)
+                                 requestPriority:NSOperationQueuePriorityNormal
+                                   progressBlock:NULL
+                                    successBlock:^(NSData *data, BOOL fromCache)
+         {
+             // Try to parse the data.
+             UIImage *thumbnailImage = [UIImage imageWithData:data];
+             
+             if (thumbnailImage != nil)
+             {
+                 // Everything is good, display the image and stop the activity indicator.
+                 self.selectionThumbnailImageView.image = thumbnailImage;
+                 
+                 [self.activityIndicator stopAnimating];
+             }
+             else
+             {
+                 NSLog(@"The returned data cannot be converted into an image.");
+             }
+         }
+                               cancellationBlock:^
+         {
+             NSLog(@"Rendition request canceled.");
+             
+             [self.activityIndicator stopAnimating];
+         }
+                                      errorBlock:^(NSError *error)
+         {
+             NSLog(@"An error occured when attempting to download a rendition: %@", error);
+             
+             [self.activityIndicator stopAnimating];
+         }];
+    }
+    else
+    {
+        NSLog(@"The selected item isn't a Library selection.");
+    }
+}
+
+- (void)assetBrowserDidEncounterError:(NSError *)error
+{
+    // Dismiss the Asset Browser
+    [self dismissViewControllerAnimated:YES completion:nil];
+    
+    // Handle the error. Here we only print out a log of the error.
+    NSLog(@"An error occurred: %@", error);
+}
+
+@end

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.m
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/ViewController.m
@@ -74,7 +74,7 @@ static NSString * const kCreativeSDKClientSecret = @"Change Me";
     AdobeUXAssetBrowserConfiguration *configuration = [AdobeUXAssetBrowserConfiguration new];
     configuration.dataSourceFilter = datasourceFilter;
     
-    // Create a new instance of the Asset Brwoser view contrller, set it's configuration and
+    // Create a new instance of the Asset Browser view controller, set it's configuration and
     // delegate and present it.
     AdobeUXAssetBrowserViewController *assetBrowser =
         [AdobeUXAssetBrowserViewController assetBrowserViewControllerWithConfiguration:configuration
@@ -122,7 +122,7 @@ static NSString * const kCreativeSDKClientSecret = @"Change Me";
         NSString *selectedImageId = librarySelection.selectedImageIDs.firstObject;
         
         // Now get the selected item, in this case an image, from the Library. Note that, for this
-        // demo, we only handline images, however all other supported Library item types can be
+        // demo, we only handle images, however all other supported Library item types can be
         // retrieved and processed.
         AdobeAssetLibraryItemImage *libraryImage = library.images[selectedImageId];
         
@@ -195,7 +195,7 @@ static NSString * const kCreativeSDKClientSecret = @"Change Me";
          }
                                       errorBlock:^(NSError *error)
          {
-             NSLog(@"An error occured when attempting to download a rendition: %@", error);
+             NSLog(@"An error occurred when attempting to download a rendition: %@", error);
              
              [self.activityIndicator stopAnimating];
          }];

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/main.m
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Objective-C/library-browser/main.m
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[])
+{
+    @autoreleasepool
+    {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser.xcodeproj/project.pbxproj
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser.xcodeproj/project.pbxproj
@@ -1,0 +1,383 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		41D75A821CEE754400F57F9B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D75A811CEE754400F57F9B /* AppDelegate.swift */; };
+		41D75A841CEE754400F57F9B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D75A831CEE754400F57F9B /* ViewController.swift */; };
+		41D75A871CEE754400F57F9B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A851CEE754400F57F9B /* Main.storyboard */; };
+		41D75A891CEE754400F57F9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A881CEE754400F57F9B /* Assets.xcassets */; };
+		41D75A8C1CEE754400F57F9B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A8A1CEE754400F57F9B /* LaunchScreen.storyboard */; };
+		41D75A941CEE75B500F57F9B /* AdobeCreativeSDKCoreResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A931CEE75B500F57F9B /* AdobeCreativeSDKCoreResources.bundle */; };
+		41D75A961CEE75CC00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A951CEE75CC00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */; };
+		41D75A981CEE75DC00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 41D75A971CEE75DC00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */; };
+		41D75A9D1CEE75EB00F57F9B /* AdobeCreativeSDKAssetModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A991CEE75EB00F57F9B /* AdobeCreativeSDKAssetModel.framework */; };
+		41D75A9E1CEE75EB00F57F9B /* AdobeCreativeSDKAssetUX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A9A1CEE75EB00F57F9B /* AdobeCreativeSDKAssetUX.framework */; };
+		41D75A9F1CEE75EB00F57F9B /* AdobeCreativeSDKCommonUX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A9B1CEE75EB00F57F9B /* AdobeCreativeSDKCommonUX.framework */; };
+		41D75AA01CEE75EB00F57F9B /* AdobeCreativeSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75A9C1CEE75EB00F57F9B /* AdobeCreativeSDKCore.framework */; };
+		41D75AA21CEE75F100F57F9B /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75AA11CEE75F100F57F9B /* libz.tbd */; };
+		41D75AA41CEE75FE00F57F9B /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75AA31CEE75FE00F57F9B /* libc++.tbd */; };
+		41D75AA71CEE761800F57F9B /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75AA51CEE761800F57F9B /* MobileCoreServices.framework */; };
+		41D75AA81CEE761800F57F9B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41D75AA61CEE761800F57F9B /* SystemConfiguration.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		41D75A7E1CEE754400F57F9B /* library-browser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "library-browser.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		41D75A811CEE754400F57F9B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		41D75A831CEE754400F57F9B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		41D75A861CEE754400F57F9B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		41D75A881CEE754400F57F9B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		41D75A8B1CEE754400F57F9B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		41D75A8D1CEE754400F57F9B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		41D75A931CEE75B500F57F9B /* AdobeCreativeSDKCoreResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKCoreResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCore.framework/Versions/A/Resources/AdobeCreativeSDKCoreResources.bundle; sourceTree = "<group>"; };
+		41D75A951CEE75CC00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKCommonUXResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCommonUX.framework/Versions/A/Resources/AdobeCreativeSDKCommonUXResources.bundle; sourceTree = "<group>"; };
+		41D75A971CEE75DC00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = AdobeCreativeSDKAssetUXResources.bundle; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetUX.framework/Versions/A/Resources/AdobeCreativeSDKAssetUXResources.bundle; sourceTree = "<group>"; };
+		41D75A991CEE75EB00F57F9B /* AdobeCreativeSDKAssetModel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKAssetModel.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetModel.framework; sourceTree = "<group>"; };
+		41D75A9A1CEE75EB00F57F9B /* AdobeCreativeSDKAssetUX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKAssetUX.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKAssetUX.framework; sourceTree = "<group>"; };
+		41D75A9B1CEE75EB00F57F9B /* AdobeCreativeSDKCommonUX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKCommonUX.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCommonUX.framework; sourceTree = "<group>"; };
+		41D75A9C1CEE75EB00F57F9B /* AdobeCreativeSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdobeCreativeSDKCore.framework; path = ../../../../../AdobeCreativeSDKFrameworks/AdobeCreativeSDKCore.framework; sourceTree = "<group>"; };
+		41D75AA11CEE75F100F57F9B /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		41D75AA31CEE75FE00F57F9B /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		41D75AA51CEE761800F57F9B /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		41D75AA61CEE761800F57F9B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		41D75AA91CEE78C500F57F9B /* library-browser-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "library-browser-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		41D75A7B1CEE754400F57F9B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75AA71CEE761800F57F9B /* MobileCoreServices.framework in Frameworks */,
+				41D75AA81CEE761800F57F9B /* SystemConfiguration.framework in Frameworks */,
+				41D75AA41CEE75FE00F57F9B /* libc++.tbd in Frameworks */,
+				41D75AA21CEE75F100F57F9B /* libz.tbd in Frameworks */,
+				41D75A9D1CEE75EB00F57F9B /* AdobeCreativeSDKAssetModel.framework in Frameworks */,
+				41D75A9E1CEE75EB00F57F9B /* AdobeCreativeSDKAssetUX.framework in Frameworks */,
+				41D75A9F1CEE75EB00F57F9B /* AdobeCreativeSDKCommonUX.framework in Frameworks */,
+				41D75AA01CEE75EB00F57F9B /* AdobeCreativeSDKCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		41D75A751CEE754400F57F9B = {
+			isa = PBXGroup;
+			children = (
+				41D75A801CEE754400F57F9B /* library-browser */,
+				41D75ACC1CEE8A7600F57F9B /* Supporting Files */,
+				41D75A7F1CEE754400F57F9B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		41D75A7F1CEE754400F57F9B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A7E1CEE754400F57F9B /* library-browser.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		41D75A801CEE754400F57F9B /* library-browser */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A811CEE754400F57F9B /* AppDelegate.swift */,
+				41D75A831CEE754400F57F9B /* ViewController.swift */,
+				41D75A851CEE754400F57F9B /* Main.storyboard */,
+				41D75A881CEE754400F57F9B /* Assets.xcassets */,
+				41D75A8A1CEE754400F57F9B /* LaunchScreen.storyboard */,
+				41D75A8D1CEE754400F57F9B /* Info.plist */,
+			);
+			path = "library-browser";
+			sourceTree = "<group>";
+		};
+		41D75ACC1CEE8A7600F57F9B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				41D75AA91CEE78C500F57F9B /* library-browser-Bridging-Header.h */,
+				41D75ACE1CEE8A8C00F57F9B /* CSDK Frameworks */,
+				41D75ACD1CEE8A8200F57F9B /* CSDK Resources */,
+				41D75ACF1CEE8A9900F57F9B /* System Frameworks */,
+			);
+			name = "Supporting Files";
+			path = "library-browser";
+			sourceTree = "<group>";
+		};
+		41D75ACD1CEE8A8200F57F9B /* CSDK Resources */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A971CEE75DC00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle */,
+				41D75A951CEE75CC00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle */,
+				41D75A931CEE75B500F57F9B /* AdobeCreativeSDKCoreResources.bundle */,
+			);
+			name = "CSDK Resources";
+			sourceTree = "<group>";
+		};
+		41D75ACE1CEE8A8C00F57F9B /* CSDK Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				41D75A991CEE75EB00F57F9B /* AdobeCreativeSDKAssetModel.framework */,
+				41D75A9A1CEE75EB00F57F9B /* AdobeCreativeSDKAssetUX.framework */,
+				41D75A9B1CEE75EB00F57F9B /* AdobeCreativeSDKCommonUX.framework */,
+				41D75A9C1CEE75EB00F57F9B /* AdobeCreativeSDKCore.framework */,
+			);
+			name = "CSDK Frameworks";
+			sourceTree = "<group>";
+		};
+		41D75ACF1CEE8A9900F57F9B /* System Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				41D75AA51CEE761800F57F9B /* MobileCoreServices.framework */,
+				41D75AA61CEE761800F57F9B /* SystemConfiguration.framework */,
+				41D75AA31CEE75FE00F57F9B /* libc++.tbd */,
+				41D75AA11CEE75F100F57F9B /* libz.tbd */,
+			);
+			name = "System Frameworks";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		41D75A7D1CEE754400F57F9B /* library-browser */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41D75A901CEE754400F57F9B /* Build configuration list for PBXNativeTarget "library-browser" */;
+			buildPhases = (
+				41D75A7A1CEE754400F57F9B /* Sources */,
+				41D75A7B1CEE754400F57F9B /* Frameworks */,
+				41D75A7C1CEE754400F57F9B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "library-browser";
+			productName = "library-browser";
+			productReference = 41D75A7E1CEE754400F57F9B /* library-browser.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		41D75A761CEE754400F57F9B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = Adobe;
+				TargetAttributes = {
+					41D75A7D1CEE754400F57F9B = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 41D75A791CEE754400F57F9B /* Build configuration list for PBXProject "library-browser" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 41D75A751CEE754400F57F9B;
+			productRefGroup = 41D75A7F1CEE754400F57F9B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				41D75A7D1CEE754400F57F9B /* library-browser */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		41D75A7C1CEE754400F57F9B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75A981CEE75DC00F57F9B /* AdobeCreativeSDKAssetUXResources.bundle in Resources */,
+				41D75A961CEE75CC00F57F9B /* AdobeCreativeSDKCommonUXResources.bundle in Resources */,
+				41D75A941CEE75B500F57F9B /* AdobeCreativeSDKCoreResources.bundle in Resources */,
+				41D75A8C1CEE754400F57F9B /* LaunchScreen.storyboard in Resources */,
+				41D75A891CEE754400F57F9B /* Assets.xcassets in Resources */,
+				41D75A871CEE754400F57F9B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		41D75A7A1CEE754400F57F9B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41D75A841CEE754400F57F9B /* ViewController.swift in Sources */,
+				41D75A821CEE754400F57F9B /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		41D75A851CEE754400F57F9B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				41D75A861CEE754400F57F9B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		41D75A8A1CEE754400F57F9B /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				41D75A8B1CEE754400F57F9B /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		41D75A8E1CEE754400F57F9B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		41D75A8F1CEE754400F57F9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		41D75A911CEE754400F57F9B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../AdobeCreativeSDKFrameworks";
+				INFOPLIST_FILE = "library-browser/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.adobe.csdk.samples.library-browser";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/$(PROJECT_NAME)/$(PROJECT_NAME)-Bridging-Header.h";
+			};
+			name = Debug;
+		};
+		41D75A921CEE754400F57F9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../../AdobeCreativeSDKFrameworks";
+				INFOPLIST_FILE = "library-browser/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.adobe.csdk.samples.library-browser";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/$(PROJECT_NAME)/$(PROJECT_NAME)-Bridging-Header.h";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		41D75A791CEE754400F57F9B /* Build configuration list for PBXProject "library-browser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41D75A8E1CEE754400F57F9B /* Debug */,
+				41D75A8F1CEE754400F57F9B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		41D75A901CEE754400F57F9B /* Build configuration list for PBXNativeTarget "library-browser" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41D75A911CEE754400F57F9B /* Debug */,
+				41D75A921CEE754400F57F9B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 41D75A761CEE754400F57F9B /* Project object */;
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:library-browser.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/AppDelegate.swift
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/AppDelegate.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate
+{
+    var window: UIWindow?
+    
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool
+    {
+        // Override point for customization after application launch.
+        return true
+    }
+    
+    func applicationWillResignActive(application: UIApplication)
+    {
+        // Sent when the application is about to move from active to inactive state. This can occur 
+        // for certain types of temporary interruptions (such as an incoming phone call or SMS 
+        // message) or when the user quits the application and it begins the transition to the 
+        // background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES 
+        // frame rates. Games should use this method to pause the game.
+    }
+    
+    func applicationDidEnterBackground(application: UIApplication)
+    {
+        // Use this method to release shared resources, save user data, invalidate timers, and 
+        // store enough application state information to restore your application to its current 
+        // state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of 
+        // applicationWillTerminate: when the user quits.
+    }
+    
+    func applicationWillEnterForeground(application: UIApplication)
+    {
+        // Called as part of the transition from the background to the inactive state; here you can 
+        // undo many of the changes made on entering the background.
+    }
+    
+    func applicationDidBecomeActive(application: UIApplication)
+    {
+        // Restart any tasks that were paused (or not yet started) while the application was 
+        // inactive. If the application was previously in the background, optionally refresh the 
+        // user interface.
+    }
+    
+    func applicationWillTerminate(application: UIApplication)
+    {
+        // Called when the application is about to terminate. Save data if appropriate. See also 
+        // applicationDidEnterBackground:.
+    }
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Base.lproj/LaunchScreen.storyboard
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Base.lproj/Main.storyboard
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Base.lproj/Main.storyboard
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="library_browser" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lsf-Df-gnH">
+                                <rect key="frame" x="225" y="20" width="150" height="30"/>
+                                <state key="normal" title="Show Library Browser"/>
+                                <connections>
+                                    <action selector="showLibraryBrowserButtonTouchUpInside" destination="BYZ-38-t0r" eventType="touchUpInside" id="Y1e-Ih-exa"/>
+                                </connections>
+                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iFD-nY-2PJ">
+                                <rect key="frame" x="20" y="58" width="560" height="522"/>
+                            </imageView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="Ize-9p-Nad">
+                                <rect key="frame" x="282" y="282" width="37" height="37"/>
+                                <color key="color" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                            </activityIndicatorView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="iFD-nY-2PJ" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="58" id="2GP-25-E3w"/>
+                            <constraint firstItem="lsf-Df-gnH" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="8pa-E3-fe3"/>
+                            <constraint firstItem="Ize-9p-Nad" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="A4D-Zr-rSm"/>
+                            <constraint firstItem="iFD-nY-2PJ" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" id="HgB-nl-kCU"/>
+                            <constraint firstItem="lsf-Df-gnH" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="20" id="L3O-Ns-glr"/>
+                            <constraint firstAttribute="bottom" secondItem="iFD-nY-2PJ" secondAttribute="bottom" constant="20" id="LvR-HW-pgQ"/>
+                            <constraint firstAttribute="trailing" secondItem="iFD-nY-2PJ" secondAttribute="trailing" constant="20" id="kT5-zP-o0d"/>
+                            <constraint firstItem="Ize-9p-Nad" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="zTb-0q-BdV"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="activityIndicator" destination="Ize-9p-Nad" id="neA-RQ-cki"/>
+                        <outlet property="selectionThumbnailImageView" destination="iFD-nY-2PJ" id="md1-bE-orB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="419" y="429"/>
+        </scene>
+    </scenes>
+</document>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Info.plist
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
@@ -66,7 +66,7 @@ class ViewController: UIViewController
         let configuration = AdobeUXAssetBrowserConfiguration()
         configuration.dataSourceFilter = dataSourceFilter
         
-        // Create a new instance of the Asset Brwoser view contrller, set it's configuration and
+        // Create a new instance of the Asset Browser view controller, set it's configuration and
         // delegate and present it.
         let assetBrowser = AdobeUXAssetBrowserViewController(configuration: configuration, delegate: self)
         
@@ -144,7 +144,7 @@ extension ViewController: AdobeUXAssetBrowserViewControllerDelegate
         }
         
         // Now get the selected item, in this case an image, from the Library. Note that, for this
-        // demo, we only handline images, however all other supported Library item types can be
+        // demo, we only handle images, however all other supported Library item types can be
         // retrieved and processed.
         guard let libraryImage = library.images[selectedImageId] as? AdobeAssetLibraryItemImage else
         {

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+
+class ViewController: UIViewController
+{
+    // TODO: Please update the ClientId and Secret to the values provided by creativesdk.com or from Adobe
+    private let kCreativeSDKClientId = "Change Me"
+    private let kCreativeSDKClientSecret = "Change Me"
+    
+    @IBOutlet weak var selectionThumbnailImageView: UIImageView!
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    
+    // MARK: -
+    override func viewDidLoad()
+    {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+        
+        // Set the client ID and secret values so the SDK can identify the calling app.
+        AdobeUXAuthManager.sharedManager().setAuthenticationParametersWithClientID(kCreativeSDKClientId,
+                                                                                   withClientSecret: kCreativeSDKClientSecret)
+    }
+    
+    override func didReceiveMemoryWarning()
+    {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    // MARK: - UI Actions
+    @IBAction func showLibraryBrowserButtonTouchUpInside()
+    {
+        // Only show the Library datasource in the Asset Browser. This helps keep this test app focused.
+        let dataSourceFilter = AdobeAssetDataSourceFilter(dataSources: [AdobeAssetDataSourceLibrary], filterType: .Inclusive)
+        
+        // Create an Asset Browser configuration object that can be used to filter the datasources and
+        // to specify the supported Library item types.
+        let configuration = AdobeUXAssetBrowserConfiguration()
+        configuration.dataSourceFilter = dataSourceFilter
+        
+        // Create a new instance of the Asset Brwoser view contrller, set it's configuration and
+        // delegate and present it.
+        let assetBrowser = AdobeUXAssetBrowserViewController(configuration: configuration, delegate: self)
+        
+        self.presentViewController(assetBrowser, animated: true, completion: nil)
+    }
+}
+
+// MARK: - AdobeUXAssetBrowserViewControllerDelegate
+extension ViewController : AdobeUXAssetBrowserViewControllerDelegate
+{
+    func assetBrowserDidSelectAssets(itemSelections: [AnyObject])
+    {
+        // Dismiss the Asset Browser view controller.
+        self.dismissViewControllerAnimated(true, completion: nil)
+        
+        // Grab the first selected item and make sure we're dealing with a Library selection object.
+        // This item is the selection object that has information about the selected item(s). We 
+        // can use this object to pinpoint the selected Library item and perform interesting tasks, 
+        // like downloading a thumbnail.
+        guard let librarySelection = itemSelections.first as? AdobeSelectionLibraryAsset else
+        {
+            print("The selected item isn't a Library selection.")
+            
+            return
+        }
+        
+        // Grab the Library object.
+        guard let library = librarySelection.selectedItem as? AdobeAssetLibrary else
+        {
+            print("No selected item found.")
+            
+            return
+        }
+        
+        // Get the first selected image ID.
+        guard let selectedImageId = librarySelection.selectedImageIDs?.first else
+        {
+            let message = "For the purposes of this demo, please select an image/graphic Library item type."
+            
+            print(message)
+            
+            let alertController = UIAlertController(title: "Demo", message: message, preferredStyle: .Alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+            
+            self.presentViewController(alertController, animated: true, completion: nil)
+            
+            return
+        }
+        
+        // Now get the selected item, in this case an image, from the Library. Note that, for this
+        // demo, we only handline images, however all other supported Library item types can be
+        // retrieved and processed.
+        guard let libraryImage = library.images[selectedImageId] as? AdobeAssetLibraryItemImage else
+        {
+            print("Although an image was selected, its ID could not be retrieved.")
+            
+            return
+        }
+        
+        // Get the rendition file reference. This reference can be used to download the rendition
+        // from the server.
+        var thumbnailFile: AdobeAssetFile? = libraryImage.rendition
+        
+        // If the Library item doesn't have a rendition, fall back to the actual image data.
+        if thumbnailFile == nil
+        {
+            thumbnailFile = libraryImage.image;
+        }
+        
+        guard thumbnailFile != nil else
+        {
+            print("No rendition or image is present for this Library image: \(libraryImage). Existing.")
+            
+            return
+        }
+        
+        // Start the activity indicator to get the user feedback.
+        activityIndicator.startAnimating()
+        
+        // Kick off the download action. Here we're requesting a PNG rendition with dimensions of
+        // 1024×1024 points. The network request priority is set to normal. We've opted to not
+        // specify a progress handler, however, we've chosen to listen for when the thumbnail is
+        // downloaded successfully, so we can display it, when the request has been canceled and
+        // for when there is an error with the request.
+        thumbnailFile?.downloadRenditionWithType(.PNG,
+            dimensions: CGSizeMake(1024, 2014),
+            requestPriority: .Normal,
+            progressBlock: nil,
+            successBlock:
+            {
+                [weak self] (data: NSData!, fromCache: Bool) in
+                
+                // Try to parse the data.
+                let thumbnailImage = UIImage(data: data)
+                
+                if (thumbnailImage != nil)
+                {
+                    // Everything is good, display the image and stop the activity indicator.
+                    self?.selectionThumbnailImageView.image = thumbnailImage;
+                    
+                    self?.activityIndicator.stopAnimating();
+                }
+                else
+                {
+                    print("The returned data cannot be converted into an image.")
+                }
+            },
+            cancellationBlock:
+            {
+                [weak self] in
+                
+                print("Rendition request canceled.")
+                
+                self?.activityIndicator.stopAnimating()
+            },
+            errorBlock:
+            {
+                [weak self](error: NSError!) in
+                
+                print("An error occurred when attempting to download a rendition: \(error)")
+                
+                self?.activityIndicator.stopAnimating()
+            }
+        )
+    }
+    
+    func assetBrowserDidEncounterError(error: NSError)
+    {
+        // Dismiss the Asset Browser
+        self.dismissViewControllerAnimated(true, completion: nil)
+        
+        // Handle the error. Here we only print out a log of the error.
+        print("An error occurred: \(error)")
+    }
+}

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/library-browser-Bridging-Header.h
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/library-browser-Bridging-Header.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Adobe Systems Incorporated. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef library_browser_Bridging_Header_h
+#define library_browser_Bridging_Header_h
+
+#import <AdobeCreativeSDKCore/AdobeCreativeSDKCore.h>
+#import <AdobeCreativeSDKAssetModel/AdobeCreativeSDKAssetModel.h>
+#import <AdobeCreativeSDKAssetUX/AdobeCreativeSDKAssetUX.h>
+
+#endif

--- a/Creative Cloud Libraries Overview/Guide/guide.md
+++ b/Creative Cloud Libraries Overview/Guide/guide.md
@@ -1,0 +1,235 @@
+# Using the Library Datasource of the Asset Browser Component
+
+_Note: You can find the complete `Library Browser` project for this guide in the [Creative SDK Samples GitHub Repository][1]._
+
+[1]: https://github.com/CreativeSDK/ios-getting-started-samples/tree/master/Creative%20Cloud%20Libraries%20Overview
+
+The `AdobeUXAssetBrowserViewController` class provides a simple UI for browsing assets stored on the Creative Cloud. You can easily restrict the types of assets or datasources that are displayed. This could be helpful to end-users to avoid confusion. For this sample project we only want to display the Creative Cloud Libraries datasource. Also, although all asset types _within_ a Library are displayed, the code only attempts to process the selected image/graphics assets. This is only a restriction of the sample project for demonstration purposes. In shipping code, each asset type can be selected and handled appropriately.
+
+##UI
+The provided interface for this sample is quite straightforward. There is a single button that instantiates the Asset Browser view controller, configures and presents it. The user is presented with an authentication screen to enter their Creative Cloud credentials. Once authenticated, the Libraries datasource of the full Asset Browser is displayed where all Libraries that the user has created or has access to are present. Each Library can be browsed and individual asset types can be selected. This UI is quite similar to the other datasources presented by the Asset Browser.
+
+## Code
+There are two main tasks that are performed:
+
+1. Instantiating and configuring the Asset Browser view controller instance.
+2. Handling the selected assets
+
+The first task is rather simple. We simply acquire an instance of the `AdobeUXAssetBrowserViewController` using the provided convenience method. We create the needed configuration object instance to restrict the displayed datasources to Libraries. Then we provide the configuration object and present it like a regular `UIViewController`:
+
+Objective-C
+
+    // Only show the Library datasource in the Asset Browser. This helps keep this test app focused.
+    AdobeAssetDataSourceFilter *datasourceFilter =
+        [[AdobeAssetDataSourceFilter alloc] initWithDataSources:@[AdobeAssetDataSourceLibrary]
+                                                     filterType:AdobeAssetDataSourceFilterInclusive];
+ 
+    // Create an Asset Browser configuration object that can be used to filter the datasources and
+    // to specify the supported Library item types.
+    AdobeUXAssetBrowserConfiguration *configuration = [AdobeUXAssetBrowserConfiguration new];
+    configuration.dataSourceFilter = datasourceFilter;
+
+     // Create a new instance of the Asset Browser view controller, set it's configuration and
+     // delegate and present it.
+    AdobeUXAssetBrowserViewController *assetBrowser =
+        [AdobeUXAssetBrowserViewController assetBrowserViewControllerWithConfiguration:configuration
+                                                                              delegate:self];
+
+    [self presentViewController:assetBrowser animated:YES completion:nil];
+
+Swift 2
+
+    // Only show the Library datasource in the Asset Browser. This helps keep this test app focused.
+    let dataSourceFilter = AdobeAssetDataSourceFilter(dataSources: [AdobeAssetDataSourceLibrary], filterType: .Inclusive)
+    
+    // Create an Asset Browser configuration object that can be used to filter the datasources and
+    // to specify the supported Library item types.
+    let configuration = AdobeUXAssetBrowserConfiguration()
+    configuration.dataSourceFilter = dataSourceFilter
+    
+    // Create a new instance of the Asset Browser view controller, set it's configuration and
+    // delegate and present it.
+    let assetBrowser = AdobeUXAssetBrowserViewController(configuration: configuration, delegate: self)
+    
+    self.presentViewController(assetBrowser, animated: true, completion: nil)
+
+The second task is the actual handling of the selected asset. For this task we first need to instantiate and start the Library Manager. Since Libraries are "living" things, meaning that they can change at any time by any of the Adobe apps that use them, we need to start the Library Manager so it can get the latest state of all the Libraries and their content. Once the Library Manger has been kicked off, we can determine whether the selected asset serves out purpose so we need to check its type. Note that since the Asset Browser presents many datasources and assets type, it's a good idea to perform this check. Although in the case of the demo we've restricted the Asset Browser to the Libraries datasource, this check is only for demonstration purposes.
+
+Once we've determined that the selected asset type is suitable for our needs (an image or graphic), we request a rendition (i.e. thumbnail) form the server. The Creative Cloud server will then generate a suitable thumbnail image based on the specified attributes and will return that thumbnail in the success block of the call. Finally, we use the returned data to display the image:
+
+    // Configure the AdobeLibraryManager and start it before we do anything. We're required to do
+    // this to make sure the latest revision of the Libraries and the contained assets are present.
+    AdobeLibraryDelegateStartupOptions *libraryManagerStartupOptions = [AdobeLibraryDelegateStartupOptions new];
+    libraryManagerStartupOptions.autoDownloadPolicy = AdobeLibraryDownloadPolicyTypeManifestOnly;
+    libraryManagerStartupOptions.autoDownloadContentTypes = @[kAdobeMimeTypePNG, kAdobeMimeTypeJPEG];
+    libraryManagerStartupOptions.elementTypesFilter = @[AdobeDesignLibraryImageElementType];
+    
+    NSString *rootLibraryDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+    rootLibraryDirectory = [rootLibraryDirectory stringByAppendingPathComponent:[NSBundle mainBundle].bundleIdentifier];
+    rootLibraryDirectory = [rootLibraryDirectory stringByAppendingPathComponent:@"libraries"];
+    
+    NSError *error = nil;
+    AdobeLibraryManager *libraryManager = [AdobeLibraryManager sharedInstance];
+    libraryManager.syncAllowedByNetworkStatusMask = AdobeNetworkReachableViaWiFi | AdobeNetworkReachableViaWWAN;
+    [libraryManager startWithFolder:rootLibraryDirectory andError:&error];
+    [libraryManager registerDelegate:self options:libraryManagerStartupOptions];
+    
+    // Grab the first selected item. This item is the a selection object that has information about
+    // the selected item(s). We can use this object to pinpoint the selected Library item and
+    // perform interesting tasks, like downloading a thumbnail.
+    AdobeSelectionLibraryAsset *librarySelection = itemSelections.firstObject;
+    
+    // Make sure we're dealing with a Library selection object.
+    if (IsAdobeSelectionLibraryAsset(librarySelection))
+    {
+        // Grab the Library object.
+        AdobeAssetLibrary *library = (AdobeAssetLibrary *)librarySelection.selectedItem;
+    
+        // Get the first selected item ID.
+        NSString *selectedImageId = librarySelection.selectedImageIDs.firstObject;
+        
+        // Now get the selected item, in this case an image, from the Library. Note that, for this
+        // demo, we only handle images, however all other supported Library item types can be
+        // retrieved and processed.
+        AdobeAssetLibraryItemImage *libraryImage = library.images[selectedImageId];
+        
+        // Get the rendition file reference. This reference can be used to download the rendition
+        // from the server.
+        AdobeAssetFile *thumbnailFile = libraryImage.rendition;
+        
+        // If the Library item doesn't have a rendition, fall back to the actual image data.
+        if (thumbnailFile == nil)
+        {
+            thumbnailFile = libraryImage.image;
+        }
+        
+        [thumbnailFile downloadRenditionWithType:AdobeAssetFileRenditionTypePNG
+                                      dimensions:CGSizeMake(1024, 1024)
+                                 requestPriority:NSOperationQueuePriorityNormal
+                                   progressBlock:NULL
+                                    successBlock:^(NSData *data, BOOL fromCache)
+         {
+             // Try to parse the data.
+             UIImage *thumbnailImage = [UIImage imageWithData:data];
+             
+             // Everything is good, display the image and stop the activity indicator.
+             self.selectionThumbnailImageView.image = thumbnailImage;
+             
+             [self.activityIndicator stopAnimating];
+         }
+                               cancellationBlock:NULL
+                                      errorBlock:NULL];
+    }
+
+Swift 2
+
+    // Configure the AdobeLibraryManager and start it before we do anything. We're required to 
+    // do this to make sure the latest revision of the Libraries and the contained assets are 
+    // present.
+    let libraryManagerStartupOptions = AdobeLibraryDelegateStartupOptions()
+    libraryManagerStartupOptions.autoDownloadPolicy = .ManifestOnly
+    libraryManagerStartupOptions.autoDownloadContentTypes = [kAdobeMimeTypePNG, kAdobeMimeTypeJPEG]
+    libraryManagerStartupOptions.elementTypesFilter = [AdobeDesignLibraryImageElementType]
+    
+    var rootLibraryDirectory: NSString = NSSearchPathForDirectoriesInDomains(.CachesDirectory, .UserDomainMask, true)[0]
+    rootLibraryDirectory = rootLibraryDirectory.stringByAppendingPathComponent(NSBundle.mainBundle().bundleIdentifier!)
+    rootLibraryDirectory = rootLibraryDirectory.stringByAppendingPathComponent("libraries")
+    
+    let libraryManager = AdobeLibraryManager.sharedInstance()
+    libraryManager.syncAllowedByNetworkStatusMask = UInt(AdobeNetworkStatus.ReachableViaWiFi.rawValue) |
+        UInt(AdobeNetworkStatus.ReachableViaWWAN.rawValue)
+    
+    do
+    {
+        // Start the Library manager
+        try libraryManager.startWithFolder(rootLibraryDirectory as String)
+        libraryManager.registerDelegate(self, options: libraryManagerStartupOptions)
+    }
+    catch let e
+    {
+        print("Could not start the Library Manager. An error occurred: \(e)")
+    }
+    
+    // Grab the first selected item and make sure we're dealing with a Library selection object.
+    // This item is the selection object that has information about the selected item(s). We 
+    // can use this object to pinpoint the selected Library item and perform interesting tasks, 
+    // like downloading a thumbnail.
+    guard let librarySelection = itemSelections.first as? AdobeSelectionLibraryAsset else
+    {
+        print("The selected item isn't a Library selection.")
+        
+        return
+    }
+    
+    // Grab the Library object.
+    guard let library = librarySelection.selectedItem as? AdobeAssetLibrary else
+    {
+        print("No selected item found.")
+        
+        return
+    }
+    
+    // Get the first selected image ID.
+    guard let selectedImageId = librarySelection.selectedImageIDs?.first else
+    {
+        let message = "For the purposes of this demo, please select an image/graphic Library item type."
+        
+        print(message)
+        
+        let alertController = UIAlertController(title: "Demo", message: message, preferredStyle: .Alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+        
+        self.presentViewController(alertController, animated: true, completion: nil)
+        
+        return
+    }
+    
+    // Now get the selected item, in this case an image, from the Library. Note that, for this
+    // demo, we only handle images, however all other supported Library item types can be
+    // retrieved and processed.
+    guard let libraryImage = library.images[selectedImageId] as? AdobeAssetLibraryItemImage else
+    {
+        print("Although an image was selected, its ID could not be retrieved.")
+        
+        return
+    }
+    
+    // Get the rendition file reference. This reference can be used to download the rendition
+    // from the server.
+    var thumbnailFile: AdobeAssetFile? = libraryImage.rendition
+    
+    // If the Library item doesn't have a rendition, fall back to the actual image data.
+    if thumbnailFile == nil
+    {
+        thumbnailFile = libraryImage.image;
+    }
+    
+    guard thumbnailFile != nil else
+    {
+        print("No rendition or image is present for this Library image: \(libraryImage). Existing.")
+        
+        return
+    }
+    
+    thumbnailFile?.downloadRenditionWithType(.PNG,
+        dimensions: CGSizeMake(1024, 2014),
+        requestPriority: .Normal,
+        progressBlock: nil,
+        successBlock:
+        {
+            [weak self] (data: NSData!, fromCache: Bool) in
+            
+            // Try to parse the data.
+            let thumbnailImage = UIImage(data: data)
+            
+            if (thumbnailImage != nil)
+            {
+                // Everything is good, display the image and stop the activity indicator.
+                self?.selectionThumbnailImageView.image = thumbnailImage;
+                
+                self?.activityIndicator.stopAnimating();
+            }
+        },
+        cancellationBlock:nil,
+        errorBlock: nil
+    )


### PR DESCRIPTION
- There are two sample projects, one in Objective-C and one in Swift, each of which demonstrates using the Library Browser to explore and select Library assets. The sample app attempts to download a rendition for the selected asset and display it in a UIImageView.
- Resolves https://trello.com/c/fmqA8ZEG

@AlexanderTung Please review and merge, thank you.