### PR TITLE
Feature/headless-api-guides

### DIFF
--- a/Asset Uploader UI Component/Code/Asset Uploader/Objective-C/AssetUploader/ViewController.m
+++ b/Asset Uploader UI Component/Code/Asset Uploader/Objective-C/AssetUploader/ViewController.m
@@ -26,6 +26,8 @@
 
 #import "ViewController.h"
 
+#define userSpecificPathKey @"userSpecificPathKey"
+
 #warning Please update the client ID and secret values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";
@@ -290,8 +292,7 @@ static NSString * const kCreativeSDKClientSecret = @"Change me";
         NSFileManager *fm = [NSFileManager defaultManager];
         [fm removeItemAtPath:[[self.rootLibDir stringByDeletingLastPathComponent] stringByDeletingLastPathComponent] error:nil];
         self.rootLibDir = nil;
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"userSpecificPathKey"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:userSpecificPathKey];
     }
 }
 
@@ -300,8 +301,7 @@ static NSString * const kCreativeSDKClientSecret = @"Change me";
 - (NSString *)UUIDForUserSpecificPath
 {
     // If we have a UUID then use it.
-    [[NSUserDefaults standardUserDefaults] synchronize];
-    NSString *userSpecificID = [[NSUserDefaults standardUserDefaults] objectForKey:@"userSpecificPathKey"];
+    NSString *userSpecificID = [[NSUserDefaults standardUserDefaults] objectForKey:userSpecificPathKey];
     
     if (userSpecificID.length > 0)
     {
@@ -309,10 +309,9 @@ static NSString * const kCreativeSDKClientSecret = @"Change me";
     }
     
     // Generate a new UUID
-    userSpecificID = [[NSUUID UUID] UUIDString];
+    userSpecificID = [NSUUID UUID].UUIDString;
     
-    [[NSUserDefaults standardUserDefaults] setObject:userSpecificID forKey:@"userSpecificPathKey"];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSUserDefaults standardUserDefaults] setObject:userSpecificID forKey:userSpecificPathKey];
     
     return userSpecificID;
 }
@@ -340,7 +339,6 @@ static NSString * const kCreativeSDKClientSecret = @"Change me";
     libMgr.syncAllowedByNetworkStatusMask = AdobeNetworkReachableViaWiFi | AdobeNetworkReachableViaWWAN;
     
     NSString *rootLibDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
-    rootLibDir = [rootLibDir stringByAppendingPathComponent:[NSBundle mainBundle].bundleIdentifier];
     rootLibDir = [rootLibDir stringByAppendingPathComponent:@"libraries"];
     
     // User specific path to sync libraries from cloud.

--- a/Creative Cloud Files API/Guide/Files_Guide.md
+++ b/Creative Cloud Files API/Guide/Files_Guide.md
@@ -53,7 +53,7 @@ In a few seconds, the file (named) is available with the rest of the files the u
 ### Code
 
 Here is the event handler for clicking the upload button from the device:
-
+```Objective-C
     + (void)uploadPhoto
     {
         UIImagePickerController *selImage = [UIImagePickerController new];
@@ -71,11 +71,12 @@ Here is the event handler for clicking the upload button from the device:
         
         [self presentViewController:selImage animated:YES completion:nil];
     }
+```
 
 We start the image-picker control, defaulting to the camera if the device supports it; otherwise, we use the photo library. (Tip: If you are testing with the simulator, your gallery may be empty. Go to any Web page, long-click on an image, and you can save that image to the simulator. Then the image will appear in the gallery.)
 
 After an image is selected, this code runs:
-
+```Objective-C
     + (void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
     {
         NSLog(@"%@", info);
@@ -127,6 +128,7 @@ After an image is selected, this code runs:
         
         [self dismissViewControllerAnimated:YES completion:nil];
     }
+```
 
 The handler is passed a dictionary of information, including the image’s location. From that, we create a temporary copy as a JPG file. We use a filename of foo.jpg; this will be important in a minute.
 

--- a/Creative Cloud Files API/Guide/Files_Guide.md
+++ b/Creative Cloud Files API/Guide/Files_Guide.md
@@ -1,6 +1,6 @@
 # Creative Cloud Files API
 
-In addition to the [Asset Browser UI Component](/articles/assetbrowser/index.html), the Creative SDK provides headless APIs for accessing Creative Cloud files directly. This guide demonstrates how to use these APIs to download existing files in the Creative Cloud and upload new files to the Creative Cloud.
+The Creative SDK provides headless APIs for accessing Creative Cloud files directly. This guide demonstrates how to use these APIs to download existing files in the Creative Cloud and upload new files to the Creative Cloud.
 
 ## Contents
 
@@ -28,8 +28,8 @@ _**Note:**_
 
 See below for a list of Classes for accessing Creative Cloud Files with our headless API:
 
-+ [AdobeAssetFile](/Classes/AdobeAssetFile.html)
-+ [AdobeAssetFolder](/Classes/AdobeAssetFolder.html)
++ [AdobeAssetFile](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeAssetFile.html)
++ [AdobeAssetFolder](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeAssetFolder.html)
 
 <a name="upload"></a>
 ## Upload Files to the Creative Cloud
@@ -139,5 +139,5 @@ Finally, a `UIAlertView` is presented to let the user know the file was uploaded
 <a name="reference"></a>
 ## Class Reference
 
-+ [AdobeAssetFile](/Classes/AdobeAssetFile.html)
-+ [AdobeAssetFolder](/Classes/AdobeAssetFolder.html)
++ [AdobeAssetFile](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeAssetFile.html)
++ [AdobeAssetFolder](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeAssetFolder.html)

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -63,6 +63,9 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
         rootLibDir = [rootLibDir stringByAppendingPathComponent:[NSBundle mainBundle].bundleIdentifier];
         rootLibDir = [rootLibDir stringByAppendingPathComponent:@"libraries"];
 
+        // Add a user-specific path. This can be a hash of some user specific information or a simple UUID which you can persist
+        // and keep track of so that you can clean up local files when user logs out.
+        rootLibDir = [rootLibDir stringByAppendingPathComponent:<user-specific-path>];
         NSError *libErr = nil;
 
         // Start the AdobeLibraryManager.

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -28,10 +28,12 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Setting up Adobe Library Manager
 * Observe for login notification
-    ```[[NSNotificationCenter defaultCenter] addObserver:self
+    ```Objective-C
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(authDidLogin:)
                                                  name:AdobeAuthManagerLoggedInNotification
-                                               object:nil];```
+                                               object:nil];
+    ```
 
 * Start AdobeLibraryManager after receiving login notification
     - (void)authDidLogin:(NSNotification *)notification

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -94,11 +94,13 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
+    ```
     - (void)syncFinished
     {
         // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.
         [[AdobeLibraryManager sharedInstance] deregisterDelegate:self];
     }
+    ```
 
 ## Remove local copies on logout
 * Observe for logout notification

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -28,10 +28,10 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Setting up Adobe Library Manager
 * Observe for login notification
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    ```[[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(authDidLogin:)
                                                  name:AdobeAuthManagerLoggedInNotification
-                                               object:nil];
+                                               object:nil];```
 
 * Start AdobeLibraryManager after receiving login notification
     - (void)authDidLogin:(NSNotification *)notification

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -1,0 +1,121 @@
+# Creative Cloud Files API
+
+The Creative SDK provides headless APIs for creating Creative Cloud(CC) Libraries and adding elements to existing libraries. This guide demonstrates how to use these APIs to upload new elements to the CC Libraries.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Upload Files to CC Libraries](#upload)
+- [Class Reference](#reference)
+
+<a name="prerequisites"></a>
+
+## Prerequisites
+
+This guide will assume that you have installed all software and completed all of the steps in the following guides:
+
+*   [Getting Started](https://creativesdk.adobe.com/docs/ios/#/articles/gettingstarted/index.html)
+*   [Framework Dependencies](https://creativesdk.adobe.com/docs/ios/#/articles/dependencies/index.html) guide.
+
+_**Note:**_
+
+*   _This component requires that the user is **logged in with their Adobe ID**._
+*   _Your Client ID must be [approved for **Production Mode** by Adobe](https://creativesdk.zendesk.com/hc/en-us/articles/204601215-How-to-complete-the-Production-Client-ID-Request) before you release your app._
+
+<a name="upload"></a>
+## Upload Files to CC Libraries 
+The AdobeLibraryManager class is responsible for managing libraries. It's a singleton class that needs to be initialized and started with startup options. It allows to create and delete libraries. The AdobeDesignLibraryUtils class defines supported element types and provides helper methods for creating each element type.
+
+## Setting up Adobe Library Manager
+* Observe for login notification
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(authDidLogin:)
+                                                 name:AdobeAuthManagerLoggedInNotification
+                                               object:nil];
+
+* Start AdobeLibraryManager after receiving login notification
+    - (void)authDidLogin:(NSNotification *)notification
+    {
+        // Below is the setup for configure & start AdobeLibraryManager.
+        // For more info regarding libraries please refer: https://creativesdk.adobe.com/docs/ios/#/articles/libraries/index.html.
+        AdobeLibraryDelegateStartupOptions *startupOptions = [AdobeLibraryDelegateStartupOptions new];
+
+        startupOptions.autoDownloadPolicy = AdobeLibraryDownloadPolicyTypeManifestOnly;
+        startupOptions.autoDownloadContentTypes = @[kAdobeMimeTypeJPEG,
+                                                    kAdobeMimeTypePNG];
+        startupOptions.elementTypesFilter = @[AdobeDesignLibraryColorElementType,
+                                              AdobeDesignLibraryColorThemeElementType,
+                                              AdobeDesignLibraryCharacterStyleElementType,
+                                              AdobeDesignLibraryBrushElementType,
+                                              AdobeDesignLibraryImageElementType,
+                                              AdobeDesignLibraryLayerStyleElementType];
+        syncOnCommit = YES;
+        libraryQueue = [NSOperationQueue mainQueue];
+        autoSyncDownloadedAssets = NO;
+
+        AdobeLibraryManager *libMgr = [AdobeLibraryManager sharedInstance];
+        libMgr.syncAllowedByNetworkStatusMask = AdobeNetworkReachableViaWiFi | AdobeNetworkReachableViaWWAN;
+
+        NSString *rootLibDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+        rootLibDir = [rootLibDir stringByAppendingPathComponent:[NSBundle mainBundle].bundleIdentifier];
+        rootLibDir = [rootLibDir stringByAppendingPathComponent:@"libraries"];
+
+        NSError *libErr = nil;
+
+        // Start the AdobeLibraryManager.
+        [libMgr startWithFolder:rootLibDir andError:&libErr];
+
+        // Register as delegate to get callbacks.
+        [libMgr registerDelegate:self options:startupOptions];
+    }
+
+## List libraries
+    NSArray <AdobeLibraryComposite *> *composites = [[AdobeLibraryManager sharedInstance] libraries];
+
+## Create a new library
+    AdobeLibraryComposite *result = [[AdobeLibraryManager sharedInstance] newLibraryWithName:<libraryName> andError:nil];
+
+    // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
+    [AdobeLibraryManager sharedInstance] sync];
+
+## Add element to a library
+    // Add assets to selected library and perform sync.
+    [AdobeDesignLibraryUtils addImage:<assetURL>
+                                 name:<assetName>
+                              library:<composite>
+                                error:nil];
+
+    // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
+    [AdobeLibraryManager sharedInstance] sync];
+
+## Clean up and shutdown
+* Implement AdobeLibraryDelegate to get callback after the sync finishes.
+    - (void)syncFinished
+    {
+        // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.
+        [[AdobeLibraryManager sharedInstance] deregisterDelegate:self];
+    }
+
+## Remove local copies on logout
+* Observe for logout notification
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(authDidLogout:)
+                                                 name:AdobeAuthManagerLoggedOutNotification
+                                               object:nil];
+
+* When user logout, clean up the local files
+    - (void)authDidLogout:(NSNotification *)notification
+    {
+        [AdobeLibraryManager removeLocalLibraryFilesInRootFolder:<rootFolder> withError:nil];
+
+        // Clean up the root folder.
+        NSFileManager *fm = [NSFileManager defaultManager];
+        [fm removeItemAtPath:[<rootFolder> stringByDeletingLastPathComponent] stringByDeletingLastPathComponent] error:nil];
+    }
+
+<a name="reference"></a>
+## Class Reference
+
++ [AdobeLibraryManager](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeLibraryManager.html)
++ [AdobeLibraryDelegateStartupOptions](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeLibraryDelegateStartupOptions.html)
++ [AdobeDesignLibraryUtils](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobeDesignLibraryUtils.html)

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -74,11 +74,11 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
     ```
 
 ## List libraries
-    ```Objective-C
+    ```
     NSArray <AdobeLibraryComposite *> *composites = [[AdobeLibraryManager sharedInstance] libraries];
     ```
 ## Create a new library
-    ```Objective-C
+    ```
     AdobeLibraryComposite *result = [[AdobeLibraryManager sharedInstance] newLibraryWithName:<libraryName> andError:nil];
 
     // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
@@ -86,7 +86,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
     ```
 
 ## Add element to a library
-    ```Objective-C
+    ```
     // Add assets to selected library and perform sync.
     [AdobeDesignLibraryUtils addImage:<assetURL>
                                  name:<assetName>
@@ -99,7 +99,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
-    ```Objective-C
+    ```
     - (void)syncFinished
     {
         // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -83,7 +83,6 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
     [AdobeLibraryManager sharedInstance] sync];
 
 ## Add element to a library
-    ```Objective-C
     // Add assets to selected library and perform sync.
     [AdobeDesignLibraryUtils addImage:<assetURL>
                                  name:<assetName>
@@ -92,17 +91,14 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
     // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
     [AdobeLibraryManager sharedInstance] sync];
-    ```
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
-    ```Objective-C
     - (void)syncFinished
     {
         // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.
         [[AdobeLibraryManager sharedInstance] deregisterDelegate:self];
     }
-    ```
 
 ## Remove local copies on logout
 * Observe for logout notification

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -74,19 +74,16 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
     ```
 
 ## List libraries
-    ```
     NSArray <AdobeLibraryComposite *> *composites = [[AdobeLibraryManager sharedInstance] libraries];
-    ```
+
 ## Create a new library
-    ```
     AdobeLibraryComposite *result = [[AdobeLibraryManager sharedInstance] newLibraryWithName:<libraryName> andError:nil];
 
     // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
     [AdobeLibraryManager sharedInstance] sync];
-    ```
 
 ## Add element to a library
-    ```
+    ```Objective-C
     // Add assets to selected library and perform sync.
     [AdobeDesignLibraryUtils addImage:<assetURL>
                                  name:<assetName>
@@ -99,7 +96,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
-    ```
+    ```Objective-C
     - (void)syncFinished
     {
         // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -36,6 +36,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
     ```
 
 * Start AdobeLibraryManager after receiving login notification
+    ```Objective-C
     - (void)authDidLogin:(NSNotification *)notification
     {
         // Below is the setup for configure & start AdobeLibraryManager.
@@ -70,17 +71,22 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
         // Register as delegate to get callbacks.
         [libMgr registerDelegate:self options:startupOptions];
     }
+    ```
 
 ## List libraries
+    ```Objective-C
     NSArray <AdobeLibraryComposite *> *composites = [[AdobeLibraryManager sharedInstance] libraries];
-
+    ```
 ## Create a new library
+    ```Objective-C
     AdobeLibraryComposite *result = [[AdobeLibraryManager sharedInstance] newLibraryWithName:<libraryName> andError:nil];
 
     // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
     [AdobeLibraryManager sharedInstance] sync];
+    ```
 
 ## Add element to a library
+    ```Objective-C
     // Add assets to selected library and perform sync.
     [AdobeDesignLibraryUtils addImage:<assetURL>
                                  name:<assetName>
@@ -89,23 +95,29 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
     // Perform sync so that the added assets are uploaded & a delegate callback is received on sync complete.
     [AdobeLibraryManager sharedInstance] sync];
+    ```
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
+    ```Objective-C
     - (void)syncFinished
     {
         // AdobeLibraryManager completed sync, hence deregister as delegate so that AdobeLibraryManager shutsdown.
         [[AdobeLibraryManager sharedInstance] deregisterDelegate:self];
     }
+    ```
 
 ## Remove local copies on logout
 * Observe for logout notification
+    ```Objective-C
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(authDidLogout:)
                                                  name:AdobeAuthManagerLoggedOutNotification
                                                object:nil];
+    ```
 
 * When user logout, clean up the local files
+    ```Objective-C
     - (void)authDidLogout:(NSNotification *)notification
     {
         [AdobeLibraryManager removeLocalLibraryFilesInRootFolder:<rootFolder> withError:nil];
@@ -114,6 +126,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
         NSFileManager *fm = [NSFileManager defaultManager];
         [fm removeItemAtPath:[<rootFolder> stringByDeletingLastPathComponent] stringByDeletingLastPathComponent] error:nil];
     }
+    ```
 
 <a name="reference"></a>
 ## Class Reference

--- a/Creative Cloud Files API/Guide/Libraries_Guide.md
+++ b/Creative Cloud Files API/Guide/Libraries_Guide.md
@@ -94,6 +94,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
 
 ## Clean up and shutdown
 * Implement AdobeLibraryDelegate to get callback after the sync finishes.
+    
     ```
     - (void)syncFinished
     {
@@ -101,7 +102,7 @@ The AdobeLibraryManager class is responsible for managing libraries. It's a sing
         [[AdobeLibraryManager sharedInstance] deregisterDelegate:self];
     }
     ```
-
+    
 ## Remove local copies on logout
 * Observe for logout notification
     ```Objective-C

--- a/Creative Cloud Files API/Guide/Photos_Guide.md
+++ b/Creative Cloud Files API/Guide/Photos_Guide.md
@@ -1,0 +1,80 @@
+# Creative Cloud Files API
+
+The Creative SDK provides headless APIs for uploading files to photos(Lightroom photos). This guide demonstrates how to use these APIs to upload files to a photo collection or a photo catalog.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Upload Files to the Photos](#upload)
+- [Class Reference](#reference)
+
+<a name="prerequisites"></a>
+
+## Prerequisites
+
+This guide will assume that you have installed all software and completed all of the steps in the following guides:
+
+*   [Getting Started](https://creativesdk.adobe.com/docs/ios/#/articles/gettingstarted/index.html)
+*   [Framework Dependencies](https://creativesdk.adobe.com/docs/ios/#/articles/dependencies/index.html) guide.
+
+_**Note:**_
+
+*   _This component requires that the user is **logged in with their Adobe ID**._
+*   _Your Client ID must be [approved for **Production Mode** by Adobe](https://creativesdk.zendesk.com/hc/en-us/articles/204601215-How-to-complete-the-Production-Client-ID-Request) before you release your app._
+
+<a name="upload"></a>
+## Upload Files to the Photos
+
+### Code
+* Use the below API in in AdobePhotoCatalog to list user photo catalogs
+    + (void)listOfType:(AdobePhotoCatalogType)type
+          successBlock:(void (^)(AdobePhotoCatalogs *catalogs))successBlock
+            errorBlock:(void (^)(NSError *error))errorBlock;
+
+* Use the below API in in AdobePhotoCatalog to list user photo collections
+    - (void)listCollectionsAfterName:(NSString *)name
+                               limit:(NSUInteger)limit
+           includeDeletedCollections:(BOOL)deleted
+                        successBlock:(void (^)(AdobePhotoCollections *collections))successBlock
+                          errorBlock:(void (^)(NSError *error))errorBlock;
+
+* Uploading to photo collection
+    // Upload assets to selected photo collection.
+    [AdobePhotoAsset create:<assetName>
+                 collection:<selectedPhotoCollection>
+                   dataPath:<assetURL>
+                contentType:kAdobeMimeTypePNG
+              progressBlock:nil
+               successBlock:^(AdobePhotoAsset *asset)
+    {
+        NSLog(@"Upload success: %@", assetName);
+    }
+          cancellationBlock:nil
+                 errorBlock:^(NSError *error)
+    {
+        NSLog(@"Upload failed: %@", error);
+    }];
+
+* Uploading to photo catalog
+    // Upload assets to selelcted photo catalog.
+    [AdobePhotoAsset create:<assetName>
+                    catalog:<selectedPhotoCatalog>
+                   dataPath:<assetURL>
+                contentType:kAdobeMimeTypePNG
+              progressBlock:nil
+               successBlock:^(AdobePhotoAsset *asset)
+    {
+        NSLog(@"Upload success: %@", assetName);
+    }
+          cancellationBlock:nil
+                 errorBlock:^(NSError *error)
+    {
+        NSLog(@"Upload failed: %@", error);
+    }];
+
+<a name="reference"></a>
+## Class Reference
+
++ [AdobePhotoAsset](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobePhotoAsset.html)
++ [AdobePhotoCatalog](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobePhotoCatalog.html)
++ [AdobePhotoCollection](https://creativesdk.adobe.com/docs/ios/#/Classes/AdobePhotoCollection.html)

--- a/Creative Cloud Files API/Guide/Photos_Guide.md
+++ b/Creative Cloud Files API/Guide/Photos_Guide.md
@@ -27,18 +27,23 @@ _**Note:**_
 AdobePhotoCatalog is the topmost container of assets in a user's lightroom photos. Each catalog contains zero or more AdobePhotoCollection. AdobePhotoCollection is a container of collections in a user's catalog. Each collection contains zero or more AdobePhotoAsset. You can upload assets to photo catalog or a photo collection.
 
 * Use the below API in AdobePhotoCatalog to list user photo catalogs
+```Objective-C
     + (void)listOfType:(AdobePhotoCatalogType)type
           successBlock:(void (^)(AdobePhotoCatalogs *catalogs))successBlock
             errorBlock:(void (^)(NSError *error))errorBlock;
+```
 
 * Use the below API in in AdobePhotoCatalog to list user photo collections
+```Objective-C
     - (void)listCollectionsAfterName:(NSString *)name
                                limit:(NSUInteger)limit
            includeDeletedCollections:(BOOL)deleted
                         successBlock:(void (^)(AdobePhotoCollections *collections))successBlock
                           errorBlock:(void (^)(NSError *error))errorBlock;
+```
 
 * Uploading to photo collection
+```Objective-C
     // Upload assets to selected photo collection.
     [AdobePhotoAsset create:<assetName>
                  collection:<selectedPhotoCollection>
@@ -54,8 +59,10 @@ AdobePhotoCatalog is the topmost container of assets in a user's lightroom photo
     {
         NSLog(@"Upload failed: %@", error);
     }];
+```
 
 * Uploading to photo catalog
+```Objective-C
     // Upload assets to selelcted photo catalog.
     [AdobePhotoAsset create:<assetName>
                     catalog:<selectedPhotoCatalog>
@@ -71,6 +78,7 @@ AdobePhotoCatalog is the topmost container of assets in a user's lightroom photo
     {
         NSLog(@"Upload failed: %@", error);
     }];
+```
 
 <a name="reference"></a>
 ## Class Reference

--- a/Creative Cloud Files API/Guide/Photos_Guide.md
+++ b/Creative Cloud Files API/Guide/Photos_Guide.md
@@ -24,9 +24,9 @@ _**Note:**_
 
 <a name="upload"></a>
 ## Upload Files to the Photos
+AdobePhotoCatalog is the topmost container of assets in a user's lightroom photos. Each catalog contains zero or more AdobePhotoCollection. AdobePhotoCollection is a container of collections in a user's catalog. Each collection contains zero or more AdobePhotoAsset. You can upload assets to photo catalog or a photo collection.
 
-### Code
-* Use the below API in in AdobePhotoCatalog to list user photo catalogs
+* Use the below API in AdobePhotoCatalog to list user photo catalogs
     + (void)listOfType:(AdobePhotoCatalogType)type
           successBlock:(void (^)(AdobePhotoCatalogs *catalogs))successBlock
             errorBlock:(void (^)(NSError *error))errorBlock;


### PR DESCRIPTION
* Formatted the headless API guide for uploading to Files. The sample app and guide already existed for this.
* Created a guide for uploading to CC libraries using the headless API's.
* Created a guide for uploading to Lightroom Photos using the headless API's.
* Updated the Asset uploader sample app to clean up local libraries when user logs out.

@mightykan @afuchs Please review.