### PR TITLE
Add verbiage about the soon-to-be deprecated components

### DIFF
--- a/Color Tool UI Component/Code/ColorComponentSampleApp/ViewController.m
+++ b/Color Tool UI Component/Code/ColorComponentSampleApp/ViewController.m
@@ -31,6 +31,8 @@
 
 #import "ViewController.h"
 
+#error The Creative SDK Color UI component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Color Tool UI Component/Guide/Guide.md
+++ b/Color Tool UI Component/Guide/Guide.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Color UI component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 # Color Tool UI Component
 
 The Creative SDK provides a color editing UI popover available on iOS. The color editing UI provides users with a number of color selection methods, including color harmony design, advanced color selection tools, and selection from your Creative Cloud Libraries. 

--- a/Creative Cloud Market UI Component/Code/Objective-C/Market Browser/ViewController.m
+++ b/Creative Cloud Market UI Component/Code/Objective-C/Market Browser/ViewController.m
@@ -25,6 +25,8 @@
 
 #import "ViewController.h"
 
+#error The Creative SDK Market Browser is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update the client ID and secret values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Creative Cloud Market UI Component/Code/Swift/Market Browser/ViewController.swift
+++ b/Creative Cloud Market UI Component/Code/Swift/Market Browser/ViewController.swift
@@ -20,6 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+The Creative SDK Market Browser is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 import UIKit
 
 class ViewController: UIViewController

--- a/Creative Cloud Market UI Component/Guide/Guide.md
+++ b/Creative Cloud Market UI Component/Guide/Guide.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Market Browser is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 #Creative Cloud Market UI Component
 
 The Creative Cloud Market is a collection of curated, high quality assets, free for use in applications by any member of the Creative Cloud. Assets include vector graphics, icons, images, and brushes. While these are available from the Creative Cloud application itself, you also can provide Market assets to users of your applications. For instance, a paint program can let your users browse brushes to enhance their creative experience.

--- a/Framework Dependencies/Guide/Guide.md
+++ b/Framework Dependencies/Guide/Guide.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Image Editor UI, Color UI, Market Browser and Labs components are no longer supported. Adobe will release a new version of the SDK in November 2017, and these components will not be included in the new version. We suggest removing these component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 # Framework Dependencies
 
 In the Creative SDK for iOS, we've broken the Foundation framework into Micro frameworks so that developers can include only the pieces that they need, thereby reducing the size of their binary. The AdobeCreativeSDKFoundation framework has been divided into the following frameworks:

--- a/Getting Started with Labs/Code/MagicBrusher/MagicBrusher/ViewController.m
+++ b/Getting Started with Labs/Code/MagicBrusher/MagicBrusher/ViewController.m
@@ -32,6 +32,8 @@
 #import <AdobeCreativeSDKLabs/AdobeLabsMagicBrush.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicCropper/MagicCropper/ViewController.m
+++ b/Getting Started with Labs/Code/MagicCropper/MagicCropper/ViewController.m
@@ -30,6 +30,8 @@
 #include <AdobeCreativeSDKLabs/AdobeLabsMagicCropper.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicCurver/MagicCurver/ViewController.m
+++ b/Getting Started with Labs/Code/MagicCurver/MagicCurver/ViewController.m
@@ -31,6 +31,8 @@
 #import <AdobeCreativeSDKLabs/AdobeLabsMagicCurve.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicCutoutMaker/MagicCutoutMaker/ViewController.m
+++ b/Getting Started with Labs/Code/MagicCutoutMaker/MagicCutoutMaker/ViewController.m
@@ -29,6 +29,8 @@
 
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicDepthMapper/MagicDepthMapper/ViewController.m
+++ b/Getting Started with Labs/Code/MagicDepthMapper/MagicDepthMapper/ViewController.m
@@ -28,6 +28,8 @@
 #import "ViewController+Buttons.h"
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicPather/MagicPather/ViewController.m
+++ b/Getting Started with Labs/Code/MagicPather/MagicPather/ViewController.m
@@ -30,6 +30,8 @@
 #import <AdobeCreativeSDKLabs/AdobeLabsMagicCurve.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicPerspectivator/MagicPerspectivator/ViewController.m
+++ b/Getting Started with Labs/Code/MagicPerspectivator/MagicPerspectivator/ViewController.m
@@ -28,6 +28,8 @@
 #import "ViewController+Buttons.h"
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicPuppy/MagicPuppy/ViewController.m
+++ b/Getting Started with Labs/Code/MagicPuppy/MagicPuppy/ViewController.m
@@ -32,6 +32,8 @@
 #import <AdobeCreativeSDKLabs/AdobeLabsUXMagicSelectionView.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicSpeecher/MagicSpeecher/ViewController.m
+++ b/Getting Started with Labs/Code/MagicSpeecher/MagicSpeecher/ViewController.m
@@ -32,6 +32,8 @@
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 #import <AdobeCreativeSDKLabs/AdobeLabsMagicAudioSpeechMatcher.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicStyler/MagicStyler/ViewController.m
+++ b/Getting Started with Labs/Code/MagicStyler/MagicStyler/ViewController.m
@@ -30,6 +30,8 @@
 #import "ViewController+Buttons.h"
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Code/MagicVectorizer/MagicVectorizer/ViewController.m
+++ b/Getting Started with Labs/Code/MagicVectorizer/MagicVectorizer/ViewController.m
@@ -30,6 +30,8 @@
 #import <AdobeCreativeSDKLabs/AdobeLabsMagicVectorizer.h>
 #import <AdobeCreativeSDKCore/AdobeUXAuthManager.h>
 
+#error The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components
+
 #warning Please update these required values to match the ones provided by creativesdk.com
 static NSString * const kCreativeSDKClientId = @"Change me";
 static NSString * const kCreativeSDKClientSecret = @"Change me";

--- a/Getting Started with Labs/Guide/Guide.md
+++ b/Getting Started with Labs/Guide/Guide.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Labs component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 # AdobeCreativeSDKLabs.framework
 
 The AdobeCreativeSDKLabs.framework (or Labs Framework) contains some of the hottest new technologies straight out of Adobe Labs.  The Labs framework provides the following technologies:

--- a/Getting Started/Guide/GettingStarted.md
+++ b/Getting Started/Guide/GettingStarted.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Image Editor UI, Color UI, Market Browser and Labs components are no longer supported. Adobe will release a new version of the SDK in November 2017, and these components will not be included in the new version. We suggest removing these components from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 # Getting Started with the iOS Creative SDK
 
 The Creative SDK lets you build applications that integrate with the Creative Cloud and leverage the power of our Creative Cloud offerings to benefit your users. From simply letting them import from and save to their Creative Cloud storage, to using innovative Photoshop APIs via your application, the Creative SDK will help you expand the features of your application by using the Adobe platform.

--- a/Image Editor UI Component/Guide/Guide.md
+++ b/Image Editor UI Component/Guide/Guide.md
@@ -1,3 +1,5 @@
+#*Note*: The Creative SDK Image Editor UI component is no longer supported. Adobe will release a new version of the SDK in November 2017, and this component will not be included in the new version. We suggest removing this component from your application as soon as possible to avoid any interruption in service. You can find more information on this deprecation here: [https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components](https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components)
+
 # Image Editor UI Component
 
 The Creative SDK Image component enables developers to add photo editing to their iOS applications. The image editor includes over 20 advanced imaging tools, covering everything from effects and crop to red-eye and blemish. All the tools are GPU-accelerated, so all image modifications happen in real time or close to it. Integrating the image editor into an application typically takes less than 15 minutes of development time.


### PR DESCRIPTION
The Creative SDK Image Editor UI, Color UI, Market Browser and Labs components are no longer supported so we're adding some verbiage to the sample projects and the user guides to inform everyone about the current state of these components and the corresponding user guides and sample projects. The guides and the projects will remain in this repository for now for reference purposes but existing code should be migrated away to stop supporting these components. No new code should be written that targets and uses these components. For more information please see https://creativesdk.zendesk.com/hc/en-us/articles/115004788463-End-of-Support-for-the-Creative-SDK-Image-Editor-UI-Color-UI-Market-Browser-and-Labs-Components