### PR TITLE
Edit argument for additionalScopeList in Swift sample code

### DIFF
--- a/Asset Browser UI Component/Code/Asset Browser/Swift/Asset Browser/ViewController.swift
+++ b/Asset Browser UI Component/Code/Asset Browser/Swift/Asset Browser/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Asset Browser UI Component/Code/PSD Extraction/Swift/PSD Extraction/ViewController.swift
+++ b/Asset Browser UI Component/Code/PSD Extraction/Swift/PSD Extraction/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Asset Uploader UI Component/Code/Asset Uploader/Swift/AssetUploader/ViewController.swift
+++ b/Asset Uploader UI Component/Code/Asset Uploader/Swift/AssetUploader/ViewController.swift
@@ -52,7 +52,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Creative Cloud Files API/Code/File Upload/Swift/File Upload/ViewController.swift
+++ b/Creative Cloud Files API/Code/File Upload/Swift/File Upload/ViewController.swift
@@ -50,7 +50,7 @@ class ViewController: UIViewController, UINavigationControllerDelegate
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
+++ b/Creative Cloud Libraries Overview/Code/Library Browser/Swift/library-browser/ViewController.swift
@@ -57,7 +57,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Creative Cloud Market UI Component/Code/Swift/Market Browser/ViewController.swift
+++ b/Creative Cloud Market UI Component/Code/Swift/Market Browser/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)

--- a/Getting Started/Code/Swift/Getting Started/ViewController.swift
+++ b/Getting Started/Code/Swift/Getting Started/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController
                                                                                    additionalScopeList: [
                                                                                     AdobeAuthManagerUserProfileScope,
                                                                                     AdobeAuthManagerEmailScope,
-                                                                                    AdobeAuthManagerUserProfileScope])
+                                                                                    AdobeAuthManagerAddressScope])
         
         // Also set the redirect URL, which is required by the CSDK authentication mechanism.
         AdobeUXAuthManager.sharedManager().redirectURL = NSURL(string: kCreativeSDKRedirectURLString)


### PR DESCRIPTION
- Replaced a duplicate of `AdobeAuthManagerUserProfileScope` for `AdobeAuthManagerAddressScope` in `setAuthenticationParametersWithClientID` method.

HI, @mightykan Could you review the PR before asking Ash to merge, please? Thanks!